### PR TITLE
ci(test): Self-test action on current branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,28 @@ on:
       - main
 jobs:
   test:
-    name: Run Pre-commit Hooks
-    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.1.4
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_ACTIONS_CHANNEL_ID: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}
+    name: Test
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-20.04
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out repository.
+        uses: actions/checkout@v3.0.2
+      - name: Cache Docker images.
+        uses: ./
+        with:
+          key: >
+            docker-${{ matrix.runner }}-${{
+              hashFiles('.pre-commit-config.yaml')
+            }}
+      - name: Run pre-commit hooks.
+        uses: ScribeMD/pre-commit-action@0.1.4
+      - name: Send Slack notification with job status.
+        if: always()
+        uses: ScribeMD/slack-templates@0.2.3
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}
+          template: result


### PR DESCRIPTION
Previously we relied on the fact that `pre-commit-action` runs `docker-cache` to test `docker-cache`. Since `pre-commit-action` pins the version of `docker-cache` to ensure its own stability, this created unnecessary friction to testing changes to `docker-cache` before they were released. Now that `pre-commit-action` has been released as an action, call it in a workflow that also self-tests `docker-cache` rather than reuse its entire workflow.