### PR TITLE
docs(pyproject): Correct name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.core.masonry.api"
   ]
 
   [tool.poetry]
-  name = "pre-commit-action"
+  name = "docker-cache"
   version = "0.1.2"
   description = "Cache Docker Images Whether Built or Pulled"
   authors = ["Kurt von Laven <kurt.von.laven@gmail.com>"]


### PR DESCRIPTION
The name pre-commit-action was erroneously used in place of docker-cache.