### PR TITLE
chore(Yarn): Pin Yarn 1.x version via asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 nodejs 16.14.2
+yarn 1.22.18
 python 3.10.4
 poetry 1.1.13


### PR DESCRIPTION
The Yarn plugin for asdf only supports Yarn 1.x, because Yarn 2+ doesn't support global installation. Hence, manage the version of Yarn 1.x in `.tool-versions`, which is only used to bootstrap Yarn 2+. Continue managing the version of Yarn 2+ in `.yarnrc.yml`.