### PR TITLE
docs(README): Format file paths as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ failed) and false on cache miss. See also
 ## Supported Runners
 
 Please refer to
-[README.md of ScribeMD/rootless-docker](https://github.com/ScribeMD/rootless-docker#supported-runners).
+[`README.md` of ScribeMD/rootless-docker](https://github.com/ScribeMD/rootless-docker#supported-runners).
 
 ## Changelog
 
-Please refer to [CHANGELOG.md](CHANGELOG.md).
+Please refer to [`CHANGELOG.md`](CHANGELOG.md).


### PR DESCRIPTION
Style file paths as code for consistency with our contributing guide and to emphasize that they are to be interpreted verbatim.