### PR TITLE
chore(Python): Upgrade all dependencies to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,11 +90,9 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.27.0 # Keep in sync with pyproject.toml.
+    rev: v2.27.1 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
-        stages:
-          - commit-msg
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,7 +27,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "commitizen"
-version = "2.27.0"
+version = "2.27.1"
 description = "Python commitizen client tool"
 category = "dev"
 optional = false
@@ -75,7 +75,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 
 [[package]]
 name = "identify"
-version = "2.5.0"
+version = "2.5.1"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -266,7 +266,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
   python-versions = "^3.10.4"
-content-hash = "9c2731b3d3294cf1412d0e9f6dda2dcd8bcbd1b2f48b0558fbbba728e6953584"
+content-hash = "add2f82646b1775135488b0499b00bfe1a5cf06a2de3758253935554bd220ebc"
 
 [metadata.files]
 argcomplete = [
@@ -282,8 +282,8 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 commitizen = [
-    {file = "commitizen-2.27.0-py3-none-any.whl", hash = "sha256:846d8caf903499d3bf48a834cdc95dad48cd7e91a62717c4649f879e248348ae"},
-    {file = "commitizen-2.27.0.tar.gz", hash = "sha256:ef18cfbf68df38b313f63ede2532dbbc62800030539544f4876a829897abd86c"},
+    {file = "commitizen-2.27.1-py3-none-any.whl", hash = "sha256:046d512c5bc795cce625211434721946f21abf713f48753f2353ec1a3e114c3f"},
+    {file = "commitizen-2.27.1.tar.gz", hash = "sha256:71a3e1fea37ced781bc440bd7d464abd5b797da8e762c1b9b632e007c2019b50"},
 ]
 decli = [
     {file = "decli-0.5.2-py3-none-any.whl", hash = "sha256:d3207bc02d0169bf6ed74ccca09ce62edca0eb25b0ebf8bf4ae3fb8333e15ca0"},
@@ -298,8 +298,8 @@ filelock = [
     {file = "filelock-3.7.0.tar.gz", hash = "sha256:b795f1b42a61bbf8ec7113c341dad679d772567b936fbd1bf43c9a238e673e20"},
 ]
 identify = [
-    {file = "identify-2.5.0-py2.py3-none-any.whl", hash = "sha256:3acfe15a96e4272b4ec5662ee3e231ceba976ef63fd9980ed2ce9cc415df393f"},
-    {file = "identify-2.5.0.tar.gz", hash = "sha256:c83af514ea50bf2be2c4a3f2fb349442b59dc87284558ae9ff54191bff3541d2"},
+    {file = "identify-2.5.1-py2.py3-none-any.whl", hash = "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa"},
+    {file = "identify-2.5.1.tar.gz", hash = "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"},
 ]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,5 @@ build-backend = "poetry.core.masonry.api"
   python = "^3.10.4"
 
   [tool.poetry.dev-dependencies]
-  commitizen = "^2.27.0" # Keep in sync with .pre-commit-config.yaml.
+  commitizen = "^2.27.1" # Keep in sync with .pre-commit-config.yaml.
   pre-commit = "^2.19.0"


### PR DESCRIPTION
Upgrade all transitive dependencies as well. The `commitizen` pre-commit hook now specifies that it runs on the `commit-msg` stage upstream, so stop specifying the hook stage here.

commitizen ^2.27.0 --> ^2.27.1