### PR TITLE
docs(tool-versions): Keep engine versions in sync

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 16.15.0
+nodejs 16.15.0 # Keep in sync with package.json.
 yarn 1.22.19
 python 3.10.4 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.1.13

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,5 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-stage.cjs
     spec: "@yarnpkg/plugin-stage"
 
+# Keep in sync with package.json.
 yarnPath: .yarn/releases/yarn-3.2.1.cjs


### PR DESCRIPTION
Remind maintainers to keep the Node.js and Yarn versions in use in sync with the `engines` field of `package.json`.