### PR TITLE
test(tsconfig): Output to build rather than dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ report
 # Poetry
 .venv
 
+# TypeScript
+build
+
 # Yarn
 .pnp.*
 .yarn/*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "moduleResolution": "node",
-    "outDir": "dist"
+    "outDir": "build"
   }
 }


### PR DESCRIPTION
ncc outputs to `dist`, and GitHub Actions requires that its output be tracked. The output of the TypeScript compiler, tsc, should not be tracked as it is only for testing/debugging purposes. Configure tsc to output to a separate `build` directory, and instruct Git to ignore it.