### PR TITLE
test(tsconfig): Configure tsc to use line feeds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "moduleResolution": "node",
+    "newLine": "lf",
     "outDir": "build"
   }
 }


### PR DESCRIPTION
By default, tsc outputs files with Windows line endings on Windows and Unix line endings on Unix systems. Since nearly all Windows tools support Unix line endings, the rest of our files are configured to use Unix line endings on all platforms for consistency. Configure tsc to do the same.