### PR TITLE
chore(MegaLinter): Upgrade from v5.13.0 to v5.14.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,2 +1,1 @@
 Laven
-vercel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.5.2
+    rev: 0.6.1
     hooks:
       - id: no-merge-commits
       - id: asdf-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: &megalinter-args [--flavor, javascript, --release, v5.13.0]
+        args: &megalinter-args [--flavor, javascript, --release, v5.14.0]
       - id: megalinter-all
         args: *megalinter-args
       - id: yarn-install


### PR DESCRIPTION
Remove "vercel" from custom dictionary; it was added to the npm dictionary upstream.

Upgrade all pre-commit hooks to latest versions.

ScribeMD/pre-commit-hooks 0.5.2 --> 0.6.1