### PR TITLE
ci(GitHub-Actions): Grant minimum necessary scopes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-20.04
+    permissions:
+      checks: write # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      contents: write # for pre-commit-action
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
Dependabot runs with read-only permissions by default for security purposes, but EnricoMi/publish-unit-test-result-action requires the `checks:write` scope, and pre-commit-action requires the `contents:write` scope. publish-unit-test-result-action uses the `checks:write` scope to display a summary of its results in a separate workflow in the GitHub Actions UI. pre-commit-action uses the `contents:write` scope to bump the project version via Commitizen. Granting these specific permissions also has the effect of reducing the scope of all unspecified permissions from read to none for pull requests from Dependabot and forks and from write to none for workflows triggered by anything else (even re-runs of Dependabot pull requests). Since this repository is public, most of its data can be read without additional permissions though.