### PR TITLE
test(docker): Sort numerically, not alphabetically

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -20,7 +20,9 @@ const assertCalledInOrder = (...mocks: jest.Mock[]): void => {
     return <number>currentMock.mock.invocationCallOrder[0];
   });
 
-  const sortedCallOrders = [...callOrders].sort();
+  const sortedCallOrders = [...callOrders].sort(
+    (a: number, b: number) => a - b
+  );
   expect(callOrders).toStrictEqual(sortedCallOrders);
 };
 


### PR DESCRIPTION
When asserting that mocks were called in the expected order, sort their call orders, which are represented as numbers, numerically. `Array.sort()` sorts alphabetically by default, so pass a comparison function to override this behavior.