### PR TITLE
style(docker.test): Specify a return type

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -21,7 +21,7 @@ const assertCalledInOrder = (...mocks: jest.Mock[]): void => {
   });
 
   const sortedCallOrders = [...callOrders].sort(
-    (a: number, b: number) => a - b
+    (a: number, b: number): number => a - b
   );
   expect(callOrders).toStrictEqual(sortedCallOrders);
 };


### PR DESCRIPTION
This allows TypeScript to enforce that a number is returned from the comparison function.