### PR TITLE
docs(README): Document required permissions

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,10 @@
+{
+  "httpHeaders": [
+    {
+      "urls": [""],
+      "headers": {
+        "Accept-Encoding": "zstd;q=1, br;q=0.9, gzip;q=0.8, deflate;q=0.7, compress;q=0.6, *;q=0.1, identity;q=0"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Cache Docker Images Whether Built or Pulled
   - [Outputs](#outputs)
     - [`cache-hit`](#cache-hit)
   - [Supported Runners](#supported-runners)
+  - [Permissions](#permissions)
   - [Changelog](#changelog)
 
 <!--TOC-->
@@ -80,6 +81,12 @@ failed) and false on cache miss. See also
 
 Please refer to
 [`README.md` of ScribeMD/rootless-docker](https://github.com/ScribeMD/rootless-docker#supported-runners).
+
+## Permissions
+
+No
+[permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+are required.
 
 ## Changelog
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -8,5 +8,6 @@ dictionaryDefinitions:
     path: .dictionary.txt
 dictionaries:
   - custom
+  - fullstack
   - npm
   - python


### PR DESCRIPTION
Configure markdown-link-check to accept any compression to avoid false positive on GitHub Docs link.