### PR TITLE
test(integration): Change Jest to `resetMocks`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from "@jest/types";
 
 const config: Config.InitialOptions = {
-  clearMocks: true,
   collectCoverage: true,
   coverageDirectory: "reports/jest/",
   coverageProvider: "v8",
@@ -14,6 +13,7 @@ const config: Config.InitialOptions = {
     },
   },
   moduleFileExtensions: ["ts", "js"],
+  resetMocks: true,
   rootDir: "src",
   testEnvironment: "node",
   watchman: true,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -18,18 +18,22 @@ describe("Integration Test", (): void => {
 
   let child_process: Mocked<typeof import("node:child_process")>;
   let cache: Mocked<typeof import("@actions/cache")>;
-  let inMemoryCache: Record<string, string>;
   let core: Mocked<typeof import("@actions/core")>;
-  let state: Record<string, string>;
   let util: typeof import("./util.js");
   let docker: typeof import("./docker.js");
 
-  beforeAll(async (): Promise<void> => {
+  let inMemoryCache: Record<string, string>;
+  let state: Record<string, string>;
+
+  beforeEach(async (): Promise<void> => {
     child_process = <any>await import("node:child_process");
     cache = <any>await import("@actions/cache");
     core = <any>await import("@actions/core");
     util = await import("./util.js");
     docker = await import("./docker.js");
+
+    inMemoryCache = {};
+    state = {};
 
     core.getInput.mockReturnValue(KEY);
 
@@ -54,11 +58,6 @@ describe("Integration Test", (): void => {
     core.saveState.mockImplementation((key: string, value: any): void => {
       state[key] = value.toString();
     });
-  });
-
-  beforeEach((): void => {
-    inMemoryCache = {};
-    state = {};
   });
 
   const mockedExec = async (load: boolean, command: string): Promise<void> => {


### PR DESCRIPTION
Change Jest configuration to `resetMocks` instead of `clearMocks` to eliminate the most substantial mechanism of cross-test interaction.