### PR TITLE
ci(GitHub-Actions): Improve pre-commit job name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   pre-commit:
-    name: pre-commit
+    name: Run Pre-commit Hooks
     runs-on: ubuntu-20.04
     permissions:
       checks: write # https://github.com/EnricoMi/publish-unit-test-result-action#permissions


### PR DESCRIPTION
Change job name to keep naming convention consistent with other repos.