### PR TITLE
test(docker): Improve test modularity

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -133,6 +133,7 @@ describe("Docker images", (): void => {
     assertCalledInOrder(
       core.getInput,
       core.getState,
+      core.getInput,
       util.execBashCommand,
       cache.saveCache
     );


### PR DESCRIPTION
Introduce `assertLoadDockerImages` to call repeated asserts. Add `getInput` argument to `assertCalledInOrder` to test `readOnly` feature.