### PR TITLE
chore(pre-commit): Bump commitizen hook to v2.32.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.31.0 # Keep in sync with pyproject.toml.
+    rev: v2.32.2 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
   - repo: https://github.com/jumanjihouse/pre-commit-hooks


### PR DESCRIPTION
When the Poetry dependency Commitizen was upgraded from v2.31.0 to v2.32.2, the pre-commit hook was left at v2.31.0.