### PR TITLE
test(integration): Assert cache not saved on hit

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -123,5 +123,6 @@ describe("Integration Test", (): void => {
     );
     expect(child_process.exec).not.toHaveBeenCalled();
     expect(core.setFailed).not.toHaveBeenCalled();
+    expect(cache.saveCache).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Add assert that `cache.saveCache` is not called upon cache hit.