### PR TITLE
test(integration): Correct `core.error` assert

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -103,7 +103,7 @@ describe("Integration Test", (): void => {
       expect.anything()
     );
     expect(core.info).nthCalledWith<[string]>(infoCallNum + 1, stdout);
-    expect(core.error).lastCalledWith(STDERR);
+    expect(core.error).nthCalledWith<[string]>(execCallNum, STDERR);
     expect(core.setFailed).not.toHaveBeenCalled();
   };
 


### PR DESCRIPTION
Since `core.error` is called twice in the save on cache miss case, use `nthCalledWith` to check each call rather than `lastCalledWith`, which checks the second call twice. This issue was asymptomatic, because the integration test always calls `core.error` with the same constant string. Reuse `execCallNum` as n for core.error since calls to it are one-to-one with calls to `child_process.exec`.