### PR TITLE
docs(README): Document filtering Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ Cache Docker Images Whether Built or Pulled
 
 <!--TOC-->
 
-Cache all Docker images whether built or pulled by
+Cache Docker images whether built or pulled by
 [saving](https://docs.docker.com/engine/reference/commandline/save/) them on
 cache misses and
 [loading](https://docs.docker.com/engine/reference/commandline/load/) them on
-cache hits. Note that this action does not perform Docker layer caching.
+cache hits. Filter out Docker images that are present before the action is run,
+notably those [pre-cached by GitHub actions](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#cached-docker-images);
+only save Docker images pulled or built in the same job after the action is run.
+Note that this action does not perform Docker layer caching.
 [The official Docker build push action](https://github.com/docker/build-push-action)
 performs Docker layer caching for built images but does not cache pulled images.
 


### PR DESCRIPTION
Functionality of docker-cache was changed to filter out images present prior to main step. Document accordingly.