### PR TITLE
test(action): Use fast-check property-based tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@actions/core": "^1.9.1"
   },
   "devDependencies": {
+    "@fast-check/jest": "^1.1.0",
     "@jest/globals": "^28.1.2",
     "@jest/types": "^28.1.1",
     "@tsconfig/node16-strictest-esm": "^1.0.3",
@@ -34,6 +35,7 @@
     "@vercel/ncc": "^0.34.0",
     "@yarnpkg/sdks": "^2.6.2",
     "eslint": "~8.19.0",
+    "fast-check": "^3.1.4",
     "jest": "^28.1.2",
     "jest-junit": "^14.0.0",
     "prettier": "2.7.1",

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,4 +1,6 @@
+import { testProp } from "@fast-check/jest";
 import { jest } from "@jest/globals";
+import { string } from "fast-check";
 
 import type { ExecOptions } from "node:child_process";
 import type { InputOptions } from "@actions/core";
@@ -15,23 +17,20 @@ const getKey = (paths: string[], key: string): string => {
 };
 
 describe("Integration Test", (): void => {
-  const KEY = "a-cache-key";
   const EXEC_OPTIONS = { shell: "/usr/bin/bash" };
-  const STDOUT = "standard output from Bash command";
-  const STDERR = "error output from Bash command";
   const LIST_COMMAND =
     'docker image list --format "{{ .Repository }}:{{ .Tag }}"';
-
-  const dockerImages: string[] = [];
 
   let child_process: Mocked<typeof import("node:child_process")>;
   let cache: Mocked<typeof import("@actions/cache")>;
   let core: Mocked<typeof import("@actions/core")>;
   let docker: typeof import("./docker.js");
 
+  let loadCommand: string;
   let inMemoryCache: Record<string, string>;
   let state: Record<string, string>;
-  let loadCommand: string;
+  let dockerImages: string[];
+  let callCount: number;
 
   beforeEach(async (): Promise<void> => {
     child_process = <any>await import("node:child_process");
@@ -39,32 +38,7 @@ describe("Integration Test", (): void => {
     core = <any>await import("@actions/core");
     docker = <any>await import("./docker.js");
 
-    inMemoryCache = {};
-    state = {};
     loadCommand = `docker load --input ${docker.DOCKER_IMAGES_PATH}`;
-
-    let callCount = 0;
-    child_process.exec.mockImplementation(
-      (command: string, _options: any, callback: any): any => {
-        let stdout;
-        if (command === LIST_COMMAND) {
-          /* When Docker is running as root, docker image list generates a list that includes a
-           * standard set of Docker images that are pre-cached by GitHub Actions. The production
-           * code filters out the Docker images present during the restore step from the list of
-           * images to save since caching pre-cached images would harm performance and waste
-           * cache space. This mock implementation of docker image list ensures a non-empty
-           * difference between the restore and save steps so there is something to save.
-           */
-          dockerImages.push(`test-docker-image:v${++callCount}`);
-          stdout = dockerImages.join("\n");
-        } else {
-          stdout = STDOUT;
-        }
-        callback(null, { stdout, stderr: STDERR });
-      }
-    );
-
-    core.getInput.mockReturnValue(KEY);
 
     cache.saveCache.mockImplementation(
       (paths: string[], key: string): Promise<any> => {
@@ -89,11 +63,40 @@ describe("Integration Test", (): void => {
     });
   });
 
+  const mockExec = (
+    listStderr: string,
+    otherStdout: string,
+    otherStderr: string
+  ): void => {
+    child_process.exec.mockImplementation(
+      (command: string, _options: any, callback: any): any => {
+        let stdout: string, stderr: string;
+        if (command === LIST_COMMAND) {
+          /* When Docker is running as root, docker image list generates a list that includes a
+           * standard set of Docker images that are pre-cached by GitHub Actions. The production
+           * code filters out the Docker images present during the restore step from the list of
+           * images to save since caching pre-cached images would harm performance and waste
+           * cache space. This mock implementation of docker image list ensures a non-empty
+           * difference between the restore and save steps so there is something to save.
+           */
+          dockerImages.push(`test-docker-image:v${++callCount}`);
+          stdout = dockerImages.join("\n");
+          stderr = listStderr;
+        } else {
+          stdout = otherStdout;
+          stderr = otherStderr;
+        }
+        callback(null, { stdout, stderr });
+      }
+    );
+  };
+
   const assertExecBashCommand = (
     infoCallNum: number,
     execCallNum: number,
     command: string,
-    stdout: string
+    stdout: string,
+    stderr: string
   ): void => {
     expect(core.info).nthCalledWith<[string]>(infoCallNum, command);
     expect(child_process.exec).nthCalledWith<[string, ExecOptions, any]>(
@@ -103,17 +106,22 @@ describe("Integration Test", (): void => {
       expect.anything()
     );
     expect(core.info).nthCalledWith<[string]>(infoCallNum + 1, stdout);
-    expect(core.error).nthCalledWith<[string]>(execCallNum, STDERR);
+    expect(core.error).nthCalledWith<[string]>(execCallNum, stderr);
     expect(core.setFailed).not.toHaveBeenCalled();
   };
 
-  const assertLoadDockerImages = (cacheHit: boolean): void => {
+  const assertLoadDockerImages = (
+    cacheHit: boolean,
+    listStderr: string,
+    loadStdout: string,
+    loadStderr: string
+  ): void => {
     expect(core.getInput).nthCalledWith<[string, InputOptions]>(1, "key", {
       required: true,
     });
     expect(core.setOutput).lastCalledWith(docker.CACHE_HIT, cacheHit);
     if (cacheHit) {
-      assertExecBashCommand(1, 1, loadCommand, STDOUT);
+      assertExecBashCommand(1, 1, loadCommand, loadStdout, loadStderr);
       expect(core.saveState).toHaveBeenCalledTimes(1);
     } else {
       expect(core.info).nthCalledWith<[string]>(
@@ -121,58 +129,103 @@ describe("Integration Test", (): void => {
         "Recording preexisting Docker images. These include standard images " +
           "pre-cached by GitHub Actions when Docker is run as root."
       );
-      assertExecBashCommand(2, 1, LIST_COMMAND, dockerImages.join("\n"));
+      assertExecBashCommand(
+        2,
+        1,
+        LIST_COMMAND,
+        dockerImages.join("\n"),
+        listStderr
+      );
     }
     expect(child_process.exec).toHaveBeenCalledTimes(1);
   };
 
-  const assertSaveCacheHit = (): void => {
+  const assertSaveCacheHit = (key: string): void => {
     expect(core.info).lastCalledWith(
-      `Cache hit occurred on the primary key ${KEY}, not saving cache.`
+      `Cache hit occurred on the primary key ${key}, not saving cache.`
     );
     expect(child_process.exec).not.toHaveBeenCalled();
     expect(core.setFailed).not.toHaveBeenCalled();
     expect(cache.saveCache).not.toHaveBeenCalled();
   };
 
-  const assertSaveCacheMiss = (): void => {
+  const assertSaveCacheMiss = (
+    listStderr: string,
+    saveStdout: string,
+    saveStderr: string
+  ): void => {
     expect(core.getInput).lastCalledWith("read-only");
     expect(core.info).nthCalledWith<[string]>(1, "Listing Docker images.");
-    assertExecBashCommand(2, 1, LIST_COMMAND, dockerImages.join("\n"));
+    assertExecBashCommand(
+      2,
+      1,
+      LIST_COMMAND,
+      dockerImages.join("\n"),
+      listStderr
+    );
     expect(core.info).nthCalledWith<[string]>(
       4,
       "Images present before restore step will be skipped; only new images " +
         "will be saved."
     );
     const saveCommand = `docker save --output ${docker.DOCKER_IMAGES_PATH} test-docker-image:v2`;
-    assertExecBashCommand(5, 2, saveCommand, STDOUT);
+    assertExecBashCommand(5, 2, saveCommand, saveStdout, saveStderr);
   };
 
-  const assertSaveDockerImages = (cacheHit: boolean): void => {
+  const assertSaveDockerImages = (
+    cacheHit: boolean,
+    key: string,
+    listStderr: string,
+    saveStdout: string,
+    saveStderr: string
+  ): void => {
     expect(core.getInput).nthCalledWith<[string, InputOptions]>(1, "key", {
       required: true,
     });
-    cacheHit ? assertSaveCacheHit() : assertSaveCacheMiss();
+    cacheHit
+      ? assertSaveCacheHit(key)
+      : assertSaveCacheMiss(listStderr, saveStdout, saveStderr);
   };
 
-  test("cache misses, then hits", async (): Promise<void> => {
-    // Attempt first cache restore.
-    await docker.loadDockerImages();
-    assertLoadDockerImages(false); // Expect cache miss since cache has never been saved.
-    jest.clearAllMocks();
+  testProp(
+    "cache misses, then hits",
+    [string(), string(), string(), string()],
+    async (
+      key: string,
+      listStderr: string,
+      otherStdout: string,
+      otherStderr: string
+    ): Promise<void> => {
+      jest.clearAllMocks();
+      inMemoryCache = {};
+      state = {};
+      dockerImages = [];
+      callCount = 0;
+      core.getInput.mockReturnValue(key);
+      mockExec(listStderr, otherStdout, otherStderr);
 
-    // Run post step first time.
-    await docker.saveDockerImages();
-    assertSaveDockerImages(false); // Expect cache saved on cache miss.
-    jest.clearAllMocks();
+      // Attempt first cache restore.
+      await docker.loadDockerImages();
+      // Expect cache miss since cache has never been saved.
+      assertLoadDockerImages(false, listStderr, otherStdout, otherStderr);
+      jest.clearAllMocks();
 
-    // Attempt second cache restore.
-    await docker.loadDockerImages();
-    assertLoadDockerImages(true); // Expect cache hit since cache has been saved.
-    jest.clearAllMocks();
+      // Run post step first time.
+      await docker.saveDockerImages();
+      // Expect cache saved on cache miss.
+      assertSaveDockerImages(false, key, listStderr, otherStdout, otherStderr);
+      jest.clearAllMocks();
 
-    // Run post step second time.
-    await docker.saveDockerImages();
-    assertSaveDockerImages(true); // Expect cache not to have been saved on cache hit.
-  });
+      // Attempt second cache restore.
+      await docker.loadDockerImages();
+      // Expect cache hit since cache has been saved.
+      assertLoadDockerImages(true, listStderr, otherStdout, otherStderr);
+      jest.clearAllMocks();
+
+      // Run post step second time.
+      await docker.saveDockerImages();
+      // Expect cache not to have been saved on cache hit.
+      assertSaveDockerImages(true, key, listStderr, otherStdout, otherStderr);
+    }
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fast-check/jest@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@fast-check/jest@npm:1.1.0"
+  dependencies:
+    fast-check: ^3.0.0
+  peerDependencies:
+    "@jest/globals": ">=25.5.2"
+  checksum: 9398c64b8f676db9455d92167b00a5f63e5b346cfcda4a01b10f04dc323c5c09ed4b34f883c4759bacb5b1e9c063259b6c2b414868da29dc7fd09d080a42dd42
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -2260,6 +2271,7 @@ __metadata:
   dependencies:
     "@actions/cache": ^3.0.0
     "@actions/core": ^1.9.1
+    "@fast-check/jest": ^1.1.0
     "@jest/globals": ^28.1.2
     "@jest/types": ^28.1.1
     "@tsconfig/node16-strictest-esm": ^1.0.3
@@ -2270,6 +2282,7 @@ __metadata:
     "@vercel/ncc": ^0.34.0
     "@yarnpkg/sdks": ^2.6.2
     eslint: ~8.19.0
+    fast-check: ^3.1.4
     jest: ^28.1.2
     jest-junit: ^14.0.0
     prettier: 2.7.1
@@ -2568,6 +2581,15 @@ __metadata:
     jest-message-util: ^28.1.1
     jest-util: ^28.1.1
   checksum: 6e557b681f4cfb0bf61efad50c5787cc6eb4596a3c299be69adc83fcad0265b5f329b997c2bb7ec92290e609681485616e51e16301a7f0ba3c57139b337c9351
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.0.0, fast-check@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "fast-check@npm:3.1.4"
+  dependencies:
+    pure-rand: ^5.0.2
+  checksum: 145dbb2708bb1ac16b237fd147a9899e7da005b52d69af7947054ef673ee420ad493750dee8a4e25011f1365fe9ddb345fa689cc3f4b00c24dcf473dbc06aa36
   languageName: node
   linkType: hard
 
@@ -4569,6 +4591,13 @@ __metadata:
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "pure-rand@npm:5.0.3"
+  checksum: a898ab8a40a8eebc641123dab19308044d8bd979efeaba1d8a45e9977593b25b00c3bd9681e2a558a7daec96c6fb8709995b8f10c55475e892b96f381bb6c6d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Property-based tests automatically generate a variety of inputs likely to expose bugs. Replace our conventional tests with property-based tests, and stop hard-coding individual test cases except where needed to ensure we maintain 100% test coverage.