### PR TITLE
chore(Yarn): Install deps for MacOS and current OS

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,6 +5,10 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-stage.cjs
     spec: "@yarnpkg/plugin-stage"
+supportedArchitectures:
+  os:
+    - current
+    - darwin
 
 # Keep in sync with package.json.
 yarnPath: .yarn/releases/yarn-3.2.3.cjs


### PR DESCRIPTION
Jest depends on fsevents, which is MacOS-specific. Hence, Yarn doesn't install it on other operating systems by default. This prevents us from running Pivotal Labs' LicenseFinder on this repository, which scans the licenses of the locally installed plugins. Force Yarn to install MacOS-dependencies so they can't break license auditing in the future.