### PR TITLE
chore(Dependabot): Add Yarn

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,6 +15,42 @@ updates:
       prefix: chore
       include: scope
 
+  # Upgrade Yarn production dependencies.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: America/New_York
+    assignees:
+      - Kurt-von-Laven
+    reviewers:
+      - Kurt-von-Laven
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-type: production
+    commit-message:
+      prefix: fix
+      include: scope
+
+  # Upgrade Yarn dev dependencies.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: America/New_York
+    assignees:
+      - Kurt-von-Laven
+    reviewers:
+      - Kurt-von-Laven
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-type: development
+    commit-message:
+      prefix: chore
+      include: scope
+
   # Upgrade Poetry dependencies.
   - package-ecosystem: pip
     directory: /


### PR DESCRIPTION
Automatically update Yarn dependencies via Dependabot. Dependabot recently enabled Yarn v2+ support in production behind a feature flag. We have the privilege of being part of the first batch of external repos to receive access! Use the `fix` prefix in commit messages for bumps to production dependencies so Commitizen bumps the patch version. Use the `chore` prefix in commit messages for bumps to development dependencies so that Commitizen doesn't bump the project version.