### PR TITLE
ci(workflow): Cache Yarn dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,20 @@ jobs:
               hashFiles('.pre-commit-config.yaml')
             }}
           read-only: true
+      - name: Get Yarn cache directory.
+        id: yarn-cache
+        run: |
+          yarn_cache="$(yarn config get cacheFolder)"
+          echo "::set-output name=path::$yarn_cache"
+      - name: Cache Yarn dependencies.
+        uses: actions/cache@v3.0.9
+        with:
+          path: ${{ steps.yarn-cache.outputs.path }}
+          key: >
+            yarn-${{ steps.os.outputs.image }}-${{ hashFiles(
+              '**/yarn.lock',
+              '.yarnrc.yml'
+            ) }}
       - name: Run pre-commit hooks.
         uses: ScribeMD/pre-commit-action@0.9.10
       - name: Publish test results to GitHub.


### PR DESCRIPTION
Improve performance of the Test workflow. Yarn dependencies are already installed via the `yarn-install` pre-commit hook.