### PR TITLE
chore(MegaLinter): Upgrade from v5.16.1 to v6.10.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,3 @@
-deps
+checkov
 Laven
 setuptools

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,7 @@ jobs:
   save-cache:
     name: Save Cache
     runs-on: ubuntu-22.04
-    permissions:
-      contents: none # workaround for https://github.com/rhysd/actionlint/issues/170
+    permissions: {}
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2
@@ -80,7 +79,7 @@ jobs:
           --show-error
           --request DELETE
           --header "Accept: application/vnd.github.v3+json"
-          --header "Authorization: token ${{ secrets.GITHUB_TOKEN }}"
+          --header "Authorization: token ${{ github.token }}"
           "https://api.github.com/repos/ScribeMD/docker-cache/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
   notify:
     name: Notify
@@ -90,8 +89,7 @@ jobs:
       - save-cache
       - restore-cache
     runs-on: ubuntu-22.04
-    permissions:
-      contents: none # workaround for https://github.com/rhysd/actionlint/issues/170
+    permissions: {}
     steps:
       - name: Send Slack notification with workflow result.
         uses: ScribeMD/slack-templates@0.6.8

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 reports
 
 # MegaLinter
-report
+megalinter-reports
 
 # Poetry
 .venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.8.0
+    rev: 0.13.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -26,9 +26,9 @@ repos:
       - id: poetry-lock
       - id: poetry-install
       - id: pre-commit-install
-      - id: megalinter
-        args: &megalinter-args [--flavor, javascript, --release, v5.16.1]
-      - id: megalinter-all
+      - id: megalinter-incremental
+        args: &megalinter-args [--flavor, javascript, --release, v6.10.0]
+      - id: megalinter-full
         args: *megalinter-args
       - id: yarn-install
       - id: yarn-dedupe

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,1 @@
+DS002 # Dockerfile only used for testing, so it's okay that user is root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # for testing purposes
+# checkov:skip=CKV_DOCKER_3:Suppress error "Ensure that a user for the container has been created" since this Dockerfile is only used for testing.
 
 FROM scratch
 LABEL description="empty image"


### PR DESCRIPTION
Replace MegaLinter v5 hooks with v6 hooks.
Suppress false positive on newly-added linter, Checkov. Change `secrets.GITHUB_TOKEN` to `github.token` in `test.yaml` to avoid triggering a false positive from Checkov.
Add `.trivyignore` because newly-added linter Trivy warns: "Specify at least 1 USER command in Dockerfile with non-root user as argument"; see [relevant Trivy documentation](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0002/). We only use the `Dockerfile` for testing, thus we are not concerned with this as a security issue.
Remove "deps" from custom dictionary; it was added to the Python dictionary upstream.
Remove workarounds for rhysd/actionlint#170 as this was fixed upstream.