### PR TITLE
test(action): Remove unneeded bespoke `Mocked` type

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -3,7 +3,6 @@ import { jest } from "@jest/globals";
 import { boolean, string, uniqueArray } from "fast-check";
 
 import type { InputOptions } from "@actions/core";
-import type { Mocked } from "./util.test.js";
 
 jest.mock("@actions/cache");
 jest.mock("@actions/core");
@@ -29,9 +28,9 @@ const assertCalledInOrder = (...mocks: jest.Mock[]): void => {
 };
 
 describe("Docker images", (): void => {
-  let cache: Mocked<typeof import("@actions/cache")>;
-  let core: Mocked<typeof import("@actions/core")>;
-  let util: Mocked<typeof import("./util.js")>;
+  let cache: jest.MockedObject<typeof import("@actions/cache")>;
+  let core: jest.MockedObject<typeof import("@actions/core")>;
+  let util: jest.MockedObject<typeof import("./util.js")>;
   let docker: typeof import("./docker.js");
 
   beforeAll(async (): Promise<void> => {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -4,7 +4,6 @@ import { string } from "fast-check";
 
 import type { ExecOptions } from "node:child_process";
 import type { InputOptions } from "@actions/core";
-import type { Mocked } from "./util.test.js";
 
 jest.unstable_mockModule("node:child_process", () => ({
   exec: jest.fn<typeof import("node:child_process").exec>(),
@@ -21,9 +20,9 @@ describe("Integration Test", (): void => {
   const LIST_COMMAND =
     'docker image list --format "{{ .Repository }}:{{ .Tag }}"';
 
-  let child_process: Mocked<typeof import("node:child_process")>;
-  let cache: Mocked<typeof import("@actions/cache")>;
-  let core: Mocked<typeof import("@actions/core")>;
+  let child_process: jest.MockedObject<typeof import("node:child_process")>;
+  let cache: jest.MockedObject<typeof import("@actions/cache")>;
+  let core: jest.MockedObject<typeof import("@actions/core")>;
   let docker: typeof import("./docker.js");
 
   let loadCommand: string;

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,7 +1,5 @@
 import { jest } from "@jest/globals";
 
-import type { Mocked } from "./util.test.js";
-
 jest.unstable_mockModule(
   "./docker.js",
   (): Partial<typeof import("./docker.js")> => ({
@@ -10,7 +8,7 @@ jest.unstable_mockModule(
 );
 
 describe("Main", (): void => {
-  let docker: Mocked<typeof import("./docker.js")>;
+  let docker: jest.MockedObject<typeof import("./docker.js")>;
 
   beforeAll(async (): Promise<void> => {
     docker = <any>await import("./docker.js");

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -1,7 +1,5 @@
 import { jest } from "@jest/globals";
 
-import type { Mocked } from "./util.test.js";
-
 jest.unstable_mockModule(
   "./docker.js",
   (): Partial<typeof import("./docker.js")> => ({
@@ -10,7 +8,7 @@ jest.unstable_mockModule(
 );
 
 describe("Post", (): void => {
-  let docker: Mocked<typeof import("./docker.js")>;
+  let docker: jest.MockedObject<typeof import("./docker.js")>;
 
   beforeAll(async (): Promise<void> => {
     docker = <any>await import("./docker.js");

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -8,11 +8,9 @@ jest.unstable_mockModule("node:child_process", () => ({
 
 jest.mock("@actions/core");
 
-type Mocked<T> = jest.MockedObject<Awaited<T>>;
-
 describe("Util", (): void => {
-  let child_process: Mocked<typeof import("node:child_process")>;
-  let core: Mocked<typeof import("@actions/core")>;
+  let child_process: jest.MockedObject<typeof import("node:child_process")>;
+  let core: jest.MockedObject<typeof import("@actions/core")>;
   let util: typeof import("./util.js");
 
   beforeAll(async (): Promise<void> => {
@@ -82,5 +80,3 @@ describe("Util", (): void => {
     );
   });
 });
-
-export { Mocked };


### PR DESCRIPTION
Jest v29 recently shipped with stronger typing. The custom `Mocked` type was never necessary. Replace it with `jest.MockedObject` since we will otherwise encounter errors on upgrade.