### PR TITLE
ci(ESLint): Ignore config files above project dir

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,3 +1,4 @@
+root: true
 extends:
   - eslint:recommended
   - plugin:@typescript-eslint/recommended


### PR DESCRIPTION
Prevent ESLint from reading any config files developers may have in ancestral directories to ensure consistency between development environments.