### PR TITLE
ci(dictionary): Remove setuptools from custom dict

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,2 @@
 checkov
 Laven
-setuptools


### PR DESCRIPTION
It is now in the CSpell Python dictionary upstream.