### PR TITLE
ci(workflow): Don't hardcode repository name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
           --request DELETE
           --header "Accept: application/vnd.github.v3+json"
           --header "Authorization: token ${{ github.token }}"
-          "https://api.github.com/repos/ScribeMD/docker-cache/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
+          "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
   notify:
     name: Notify
     if: always()


### PR DESCRIPTION
Prefer the environment variable `$GITHUB_REPOSITORY` for the sake of reusability and succinctness.