### PR TITLE
ci(workflow): Prefer "Bearer" to "token" for auth

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
           --show-error
           --request DELETE
           --header "Accept: application/vnd.github.v3+json"
-          --header "Authorization: token ${{ github.token }}"
+          --header "Authorization: Bearer ${{ github.token }}"
           "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
   notify:
     name: Notify


### PR DESCRIPTION
"Bearer" is recommended by the official GitHub documentation, because it works with JSON web tokens (JWT).