### PR TITLE
ci(workflow): Prefer `'` to `"` for string literals

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Verify Docker loaded empty image from cache.
         run: |
           description="$(docker inspect --format '{{ index .Config.Labels "description" }}' empty)"
-          [[ $description == "empty image" ]]
+          [[ $description == 'empty image' ]]
       - name: Delete test cache.
         if: always()
         run: >
@@ -92,8 +92,8 @@ jobs:
           --silent
           --show-error
           --request DELETE
-          --header "Accept: application/vnd.github.v3+json"
-          --header "Authorization: Bearer ${{ github.token }}"
+          --header 'Accept: application/vnd.github.v3+json'
+          --header 'Authorization: Bearer ${{ github.token }}'
           "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
   notify:
     name: Notify


### PR DESCRIPTION
Single quotes prevent evaluation of Bash syntax, such as variable interpolation, so they are simpler and safer when variable interpolation is not desired.