### PR TITLE
chore(MegaLinter): Sort non-tool-specific keys

### DIFF
--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -1,7 +1,7 @@
 APPLY_FIXES: all
-FILTER_REGEX_EXCLUDE: \.pnp\.(c|loader\.m)js|\.yarn/|dist
 DEFAULT_BRANCH: main
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
+FILTER_REGEX_EXCLUDE: \.pnp\.(c|loader\.m)js|\.yarn/|dist
 FORMATTERS_DISABLE_ERRORS: false
 PRINT_ALPACA: false
 SHOW_ELAPSED_TIME: true


### PR DESCRIPTION
Keep config keys that pertain to all tools in alphabetical order.