### PR TITLE
ci(workflow): Print error messages from GitHub API

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
         if: always()
         run: >
           curl
-          --fail
+          --fail-with-body
           --silent
           --show-error
           --request DELETE


### PR DESCRIPTION
Replace `--fail` with `--fail-with-body` in cURL invocation that deletes test cache. This causes cURL to display any error message it may receive from the server, which is often helpful context to have when debugging.