### PR TITLE
ci(workflow): Support running workflow from forks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Save Docker images.
         uses: ./
         with:
-          key: docker-cache-test
+          key: docker-cache-test-${{ github.run_attempt }}
       - name: Build an empty test Docker image.
         run: docker build --tag empty .
   restore-cache:
@@ -79,12 +79,12 @@ jobs:
       - name: Load Docker images.
         uses: ./
         with:
-          key: docker-cache-test
+          key: docker-cache-test-${{ github.run_attempt }}
       - name: Verify Docker loaded empty image from cache.
         run: |
           description="$(docker inspect --format '{{ index .Config.Labels "description" }}' empty)"
           [[ $description == 'empty image' ]]
-      - name: Delete test cache.
+      - name: Delete test cache if permitted (i.e., workflow not triggered from fork).
         if: always()
         run: >
           curl
@@ -94,7 +94,8 @@ jobs:
           --request DELETE
           --header 'Accept: application/vnd.github.v3+json'
           --header 'Authorization: Bearer ${{ github.token }}'
-          "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test&ref=$GITHUB_REF"
+          "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test-${{ github.run_attempt }}&ref=$GITHUB_REF" ||
+          (( $? == 22 ))
   notify:
     name: Notify
     if: always()


### PR DESCRIPTION
The Restore Cache job fails when run from a forked repository, because forks have read-only permissions to GitHub APIs for security purposes. Suppress the failure in the failing step that deletes the test cache since the test cache is less than 2 KB in size. Make the test cache key unique to each workflow run attempt in order to continue testing cache saves after a run from a forked repository. This also eliminates a short race condition that previously could have resulted in false positives when the workflow was run concurrently with itself.