### PR TITLE
chore(Commitizen): Don't bump major version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "poetry.core.masonry.api"
     "pyproject.toml:version",
     "README.md:docker-cache@"
   ]
+  major_version_zero = true
 
   [tool.poetry]
   name = "docker-cache"


### PR DESCRIPTION
Normally, Commitizen, in compliance with semantic versioning, bumps the project's major version on breaking changes. At major version 0, any release can have breaking changes, and bumping the major version to 1 signifies the stability of the public API. We are currently at major version 0, so configure Commitizen not to bump the major version on breaking changes.