### PR TITLE
ci(pre-commit): Forbid all Git submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
       - id: detect-private-key
-      - id: forbid-new-submodules
+      - id: forbid-submodules
       - id: no-commit-to-branch
 
   # Check for issues.


### PR DESCRIPTION
Switch from forbid-new-submodules to the newly added forbid-submodules pre-commit hook.