### PR TITLE
chore(Poetry): Pin all dependencies by removing `^`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -287,8 +287,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.11.0"
-content-hash = "b4e6503a9c17b8902a32957b9050b8bfd54ecf86a4559e5a66eecfdcd6b05039"
+python-versions = "3.11.0"
+content-hash = "d2d4409d7aac7f977836f4370538c8184dbc1c5c7d46aa46cba228fa240c46a6"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "^3.11.0"
+  python = "3.11.0"
 
   [tool.poetry.dev-dependencies]
-  commitizen = "^2.37.0" # Keep in sync with .pre-commit-config.yaml.
-  pre-commit = "^2.20.0"
+  commitizen = "2.37.0" # Keep in sync with .pre-commit-config.yaml.
+  pre-commit = "2.20.0"


### PR DESCRIPTION
Using `^` allows the dependency version in use to exceed the version listed in `pyproject.toml`. When `poetry update` is run, `poetry.lock` is updated with the latest version of both direct and transitive dependencies, but `pyproject.toml` is not updated. The extra complexity of permitting `pyproject.toml` and `poetry.lock` to differ provides no value since we use Renovate to keep all of our dependencies up to date. Furthermore, using `^` can lead to direct dependency bumps being included in Renovate lock file maintenance rather than a dedicated pull request. Renovate subsequently opens pull requests that update `pyproject.toml` accordingly but with confusing commit messages based on the lock file stating the direct dependency was bumped from `x.y.z` to `x.y.z`. Pinning dependencies keeps `pyproject.toml` and `poetry.lock` in sync, and ensures that Renovate updates both in tandem in dedicated pull requests for direct dependencies.