### PR TITLE
chore(Poetry): Use `==` to specify exact versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -287,8 +287,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.11.0"
-content-hash = "d2d4409d7aac7f977836f4370538c8184dbc1c5c7d46aa46cba228fa240c46a6"
+python-versions = "==3.11.0"
+content-hash = "a48993aad133d36b4c22d33089251ebdcf14c93bf8773e7564c9c34be2856310"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "3.11.0"
+  python = "==3.11.0"
 
   [tool.poetry.dev-dependencies]
-  commitizen = "2.37.0" # Keep in sync with .pre-commit-config.yaml.
-  pre-commit = "2.20.0"
+  commitizen = "==2.37.0" # Keep in sync with .pre-commit-config.yaml.
+  pre-commit = "==2.20.0"


### PR DESCRIPTION
While Poetry appears to interpret the missing version constraints as exact version requirements, the official documentation requires use of a version constraint, such as `==`.