### PR TITLE
docs(README): Clarify how to create a cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ performs Docker layer caching for built images but does not cache pulled images.
   - name: Cache Docker images.
     uses: ScribeMD/docker-cache@0.2.8
     with:
-      key: docker-${{ runner.os }}-${{ hashFiles(...) }}
+      key: docker-${{ runner.os }}-${{ hashFiles(paths) }}
   ```
+
+- Change the key to some fast function of your Docker image versions, for
+  example, `docker-${{ runner.os }}-${{ hashFiles('docker-compose.yaml') }}`,
+  if `docker-compose.yaml` specifies the Docker images you pull. Refer to the
+  [official GitHub cache action](https://github.com/marketplace/actions/cache#creating-a-cache-key)
+  for guidance on creating a cache key.
 
 ## Inputs
 


### PR DESCRIPTION
Resolves #97.

Replace `hashFiles(...)` with `hashFiles(paths)` to make it clear that `...` isn't a special symbol and that the user ought to pass one or more filepaths to `hashFiles`. Explicitly document that the user must select an appropriate key and cannot copy the example verbatim. Link to the specific section of the official GitHub cache action that documents how to create a cache key.