### PR TITLE
ci(workflow): Partially restore Yarn cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,7 @@ jobs:
               '**/yarn.lock',
               '.yarnrc.yml'
             ) }}
+          restore-keys: yarn-${{ steps.os.outputs.IMAGE }}-
       - name: Run pre-commit hooks.
         uses: ScribeMD/pre-commit-action@0.9.43
       - name: Publish test results to GitHub.


### PR DESCRIPTION
Implement partial cache restoration for Yarn, allowing cache hits when Yarn dependencies are upgraded. Yarn prevents partial cache restoration snowballing by removing no longer needed dependencies from the cache when `yarn install` is run.