### PR TITLE
chore(tsconfig): Upgrade from node16 to node18

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fast-check/jest": "1.6.0",
     "@jest/globals": "29.4.3",
     "@jest/types": "29.4.3",
-    "@tsconfig/node16-strictest-esm": "1.0.3",
+    "@tsconfig/node18-strictest-esm": "1.0.1",
     "@types/eslint": "8.21.1",
     "@types/jest": "29.4.0",
     "@types/node": "18.14.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16-strictest-esm/tsconfig.json",
+  "extends": "@tsconfig/node18-strictest-esm/tsconfig.json",
   "include": ["src/**/*.ts"],
   "exclude": ["**/reports"],
   "compilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,17 +1131,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16-strictest-esm@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@tsconfig/node16-strictest-esm@npm:1.0.3"
-  checksum: cc5650a1752e29f1adf5c4ff0a60e4f948c34d5a1e489a4504f3125c8b9b6f915f94dcd06e0936211a349d067469380e25f6ab461a4c0fd4a3b71c7108378fd7
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node16@npm:^1.0.2":
   version: 1.0.3
   resolution: "@tsconfig/node16@npm:1.0.3"
   checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node18-strictest-esm@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@tsconfig/node18-strictest-esm@npm:1.0.1"
+  checksum: 9da55e6959defe1115996e3360decbf70f83fae925967c418a5a387db52daa005f6b270b858bea42d74c134ff7155157c5cabbfecc9c783fd1129e354ec2f31c
   languageName: node
   linkType: hard
 
@@ -2435,7 +2435,7 @@ __metadata:
     "@fast-check/jest": 1.6.0
     "@jest/globals": 29.4.3
     "@jest/types": 29.4.3
-    "@tsconfig/node16-strictest-esm": 1.0.3
+    "@tsconfig/node18-strictest-esm": 1.0.1
     "@types/eslint": 8.21.1
     "@types/jest": 29.4.0
     "@types/node": 18.14.0


### PR DESCRIPTION
We already upgraded from Node.js 16 to 18, so reflect that in our TypeScript configuration by upgrading from @tsconfig/node16-strictest-esm to @tsconfig/node18-strictest-esm.