### PR TITLE
test(Jest): Remove `testEnvironment` and `watchman`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,8 +15,6 @@ const config: JestConfigWithTsJest = {
   moduleFileExtensions: ["ts", "js"],
   resetMocks: true,
   rootDir: "src",
-  testEnvironment: "node",
-  watchman: true,
 
   // See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support#use-esm-presets.
   preset: "ts-jest/presets/default-esm",


### PR DESCRIPTION
`testEnvironment` began defaulting to `"node"` in Jest 27, and we are currently on Jest 29. `watchman` defaulted to `true` all long.