### PR TITLE
test(jest.config): Stop transforming `*.js` files

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ const config: JestConfigWithTsJest = {
   // See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support#use-esm-presets.
   preset: "ts-jest/presets/default-esm",
   transform: {
-    "^.+\\.[jt]s$": ["ts-jest", { useESM: true }],
+    "^.+\\.ts$": ["ts-jest", { useESM: true }],
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",


### PR DESCRIPTION
Jest only runs on the `*.ts` files in the `src` directory, so there have never been any `*.js` source files for ts-jest to transform. tsc and @vercel/ncc generate `*.js` output files in the `build` and `dist` directories, respectively, but ts-jest doesn't transform these.