### PR TITLE
ci(workflow): Stop publishing nonexistent report

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,9 +69,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2.4.1
         if: always()
         with:
-          junit_files: |
-            reports/jest/junit.xml
-            reports/junit/*.xml
+          junit_files: reports/jest/junit.xml
           comment_mode: off
   save-cache:
     name: Save Cache


### PR DESCRIPTION
There was never anything generating a report at a path matching `reports/junit/*.xml`, so instructing EnricoMi/publish-unit-test-result-action to search for one there only served to slow it down.