### PR TITLE
test(Jest): Update paths to reflect `rootDir` routes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2.4.1
         if: always()
         with:
-          junit_files: reports/jest/junit.xml
+          junit_files: src/reports/jest/junit.xml
           comment_mode: off
   save-cache:
     name: Save Cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Jest
-reports
+src/reports
 
 # MegaLinter
 megalinter-reports

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,7 +29,9 @@ const config: JestConfigWithTsJest = {
 if (process.env["CI"] === "true") {
   config.ci = true;
   config.collectCoverageFrom = ["**/*.ts"];
-  config.reporters = [["jest-junit", { outputDirectory: "reports/jest/" }]];
+  config.reporters = [
+    ["jest-junit", { outputDirectory: "<rootDir>/reports/jest/" }],
+  ];
 }
 
 export default config;


### PR DESCRIPTION
`coverageDirectory` is relative to `rootDir`, so Jest outputs test coverage reports to `src/reports/jest/` rather than `reports/jest/`. `outputDirectory` is not relative to `rootDir`, so include `rootDir` explicitly in the path so that unit tests are reported to the same directory as test coverage.