### PR TITLE
ci(workflow): Replace `junit_files` with `files`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2.4.1
         if: always()
         with:
-          junit_files: src/reports/jest/junit.xml
+          files: src/reports/jest/junit.xml
           comment_mode: off
   save-cache:
     name: Save Cache


### PR DESCRIPTION
The `junit_files` argument to [EnricoMi/publish-unit-test-result-action](https://github.com/EnricoMi/publish-unit-test-result-action) was deprecated in favor of `files`.