### PR TITLE
chore(VSCode): Don't trim Git patch whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.diff]
+# Preserve trailing whitespace so as not to break Git patch editing.
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[diff]": {
+    "files.trimTrailingWhitespace": false
+  },
   "editor.tabSize": 2,
   "editorconfig.generateAuto": false,
   "eslint.nodePath": ".yarn/sdks",


### PR DESCRIPTION
VSCode and the EditorConfig VSCode extension are configured to trim trailing whitespace. This is generally desirable, but breaks Git patch editing, so disable whitespace trimming for `*.diff` files for both VSCode and EditorConfig.