### PR TITLE
ci(gitattributes): Ignore `*.mjs` whitespace errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 # Yarn generates some JavaScript files that are technically text, but that we
 # don't want Git to check for whitespace errors.
 *.cjs binary
+*.mjs binary
 
 # As of 2022-04-21, Git mistakenly categorizes Yarn cache files as textual.
 *.zip binary


### PR DESCRIPTION
Yarn generates `.pnp.loader.mjs` for ESM (ECMAScript modules) support. We already correctly configure Git to ignore whitespace errors in Yarn CJS (CommonJS) files, so do the same for `*.mjs` files.