### PR TITLE
ci(workflow): Set top-level permissions to `{}`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,13 +6,14 @@ on:
   push:
     branches:
       - main
-permissions:
-  checks: write # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
-  contents: write # for pre-commit-action
+permissions: {}
 jobs:
   pre-commit:
     name: Run Pre-commit Hooks
     runs-on: ubuntu-22.04
+    permissions:
+      checks: write # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      contents: write # for pre-commit-action
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.3.0
@@ -74,7 +75,6 @@ jobs:
   save-cache:
     name: Save Cache
     runs-on: ubuntu-22.04
-    permissions: {}
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.3.0
@@ -126,7 +126,6 @@ jobs:
       - save-cache
       - restore-cache
     runs-on: ubuntu-22.04
-    permissions: {}
     steps:
       - name: Send Slack notification with workflow result.
         uses: ScribeMD/slack-templates@0.6.13


### PR DESCRIPTION
Add minimal permissions to each job as needed rather than start broad and subtract.