### PR TITLE
test(util): Remove unnecessary typing

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -23,8 +23,8 @@ describe("Util", (): void => {
     const mockedExec = async (
       command: string,
       error: Error | null,
-      stdout: string = "",
-      stderr: string = ""
+      stdout = "",
+      stderr = ""
     ): Promise<string> => {
       child_process.exec.mockImplementationOnce(<typeof child_process.exec>((
         _command: any,


### PR DESCRIPTION
TypeScript automatically infers the type of `""` to be `string`.