### PR TITLE
chore(VSCode): Remove no longer needed exclude

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,7 @@
   "search.exclude": {
     "poetry.lock": true,
     "/dist": true,
-    "**/.yarn": true,
-    "**/.pnp.*": true
+    "**/.yarn": true
   },
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": ".yarn/sdks/typescript/lib"


### PR DESCRIPTION
VSCode search now excludes gitignored files by default.