### PR TITLE
chore(VSCode): Include `poetry.lock` when searching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,6 @@
   "python.defaultInterpreterPath": "./.venv/bin/python",
   "python.terminal.activateEnvInCurrentTerminal": true,
   "search.exclude": {
-    "poetry.lock": true,
     "/dist": true,
     "**/.yarn": true
   },


### PR DESCRIPTION
Occasionally one may desire to search the Poetry lock file. Search results from the lock file may be ignored temporarily by collapsing them or permanently via the user setting `search.exclude`.