### PR TITLE
test(action): Remove unnecessary `beforeAll`s

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,13 +8,8 @@ jest.unstable_mockModule(
 );
 
 describe("Main", (): void => {
-  let docker: jest.MockedObject<typeof import("./docker.js")>;
-
-  beforeAll(async (): Promise<void> => {
-    docker = <any>await import("./docker.js");
-  });
-
   test("loads Docker images on module load", async (): Promise<void> => {
+    const docker = jest.mocked(await import("./docker.js"));
     await import("./main.js");
 
     expect(docker.loadDockerImages).lastCalledWith();

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -8,13 +8,8 @@ jest.unstable_mockModule(
 );
 
 describe("Post", (): void => {
-  let docker: jest.MockedObject<typeof import("./docker.js")>;
-
-  beforeAll(async (): Promise<void> => {
-    docker = <any>await import("./docker.js");
-  });
-
   test("saves Docker images on module load", async (): Promise<void> => {
+    const docker = jest.mocked(await import("./docker.js"));
     await import("./post.js");
 
     expect(docker.saveDockerImages).lastCalledWith();


### PR DESCRIPTION
Simplify `main.test.ts` and `post.test.ts` by moving the contents of their `beforeAll`s into their single tests. Use `jest.mocked()` to automatically convert the type of the imported docker modules to `jest.MockedObject<typeof import("./docker.js")>`.