### PR TITLE
test(action): Prefer `jest.mocked()` to `<any>`

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -39,9 +39,9 @@ describe("Docker images", (): void => {
   let docker: typeof import("./docker.js");
 
   beforeAll(async (): Promise<void> => {
-    cache = <any>await import("@actions/cache");
-    core = <any>await import("@actions/core");
-    util = <any>await import("./util.js");
+    cache = jest.mocked(await import("@actions/cache"));
+    core = jest.mocked(await import("@actions/core"));
+    util = jest.mocked(await import("./util.js"));
     docker = await import("./docker.js");
   });
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -32,10 +32,10 @@ describe("Integration Test", (): void => {
   let callCount: number;
 
   beforeEach(async (): Promise<void> => {
-    child_process = <any>await import("node:child_process");
-    cache = <any>await import("@actions/cache");
-    core = <any>await import("@actions/core");
-    docker = <any>await import("./docker.js");
+    child_process = jest.mocked(await import("node:child_process"));
+    cache = jest.mocked(await import("@actions/cache"));
+    core = jest.mocked(await import("@actions/core"));
+    docker = jest.mocked(await import("./docker.js"));
 
     loadCommand = `docker load --input ${docker.DOCKER_IMAGES_PATH}`;
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -14,8 +14,8 @@ describe("Util", (): void => {
   let util: typeof import("./util.js");
 
   beforeAll(async (): Promise<void> => {
-    child_process = <any>await import("node:child_process");
-    core = <any>await import("@actions/core");
+    child_process = jest.mocked(await import("node:child_process"));
+    core = jest.mocked(await import("@actions/core"));
     util = await import("./util.js");
   });
 


### PR DESCRIPTION
Casting mocked modules to `any` prevents TypeScript from type checking. Jest offers `jest.mocked()` for the purpose of decorating the types of mocked objects with their Jest-imbued functions and properties. This allows TypeScript to enforce that the appropriate mock is assigned to the appropriate variable, for instance.