### PR TITLE
ci(workflow): Correct cache key for delete step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,6 +131,8 @@ jobs:
           --header 'Accept: application/vnd.github.v3+json'
           --header 'Authorization: Bearer ${{ github.token }}'
           "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-cache-test-${{
+            matrix.os
+          }}-${{
             github.run_id
           }}-${{
             github.run_attempt


### PR DESCRIPTION
When we added Windows support, the cache key for the delete step in our test workflow was not updated accordingly.