### PR TITLE
style(util): Introduce `ConsoleOutput` type

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,4 @@
+arbitraries
 Laven
 ltsc
 nanoserver

--- a/src/arbitraries/util.ts
+++ b/src/arbitraries/util.ts
@@ -1,0 +1,14 @@
+import { constantFrom, record, string } from "fast-check";
+
+import type { Arbitrary } from "fast-check";
+
+import type { ConsoleOutput } from "../util.js";
+
+export const consoleOutput = (): Arbitrary<ConsoleOutput> =>
+  record({
+    stdout: string(),
+    stderr: string(),
+  });
+
+export const platform = (): Arbitrary<NodeJS.Platform> =>
+  constantFrom("linux", "win32");

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,11 @@ const execAsPromised = promisify(exec);
 
 import { error, info, setFailed } from "@actions/core";
 
+type ConsoleOutput = {
+  stdout: string;
+  stderr: string;
+};
+
 const execBashCommand = async (
   command: string,
   platform: NodeJS.Platform = process.platform
@@ -13,16 +18,16 @@ const execBashCommand = async (
     platform === "win32"
       ? "C:\\Program Files\\Git\\bin\\bash.exe"
       : "/usr/bin/bash";
-  let output = "";
+  let stdout = "";
   try {
-    const result = await execAsPromised(command, { shell });
-    output = result.stdout;
-    info(output);
-    error(result.stderr);
+    const output: ConsoleOutput = await execAsPromised(command, { shell });
+    stdout = output.stdout;
+    info(stdout);
+    error(output.stderr);
   } catch (error: any) {
     setFailed(error.toString());
   }
-  return output;
+  return stdout;
 };
 
-export { execBashCommand };
+export { ConsoleOutput, execBashCommand };


### PR DESCRIPTION
Stdout and stderr frequently co-occur, so wrap them in a dedicated type. Create a corresponding fast-check arbitrary, `consoleOutput()`. Move our existing custom arbitrary, `platform()`, into the new dedicated arbitrary file, `src/arbitraries/util.ts`. Leverage `ConsoleOutput` in a new helper method, `joinOutput()`, to reduce duplication in the integration test.