### PR TITLE
test(integration): Remove incorrect use of `jest.mocked()`

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -38,7 +38,7 @@ describe("Integration Test", (): void => {
     child_process = jest.mocked(await import("node:child_process"));
     cache = jest.mocked(await import("@actions/cache"));
     core = jest.mocked(await import("@actions/core"));
-    docker = jest.mocked(await import("./docker.js"));
+    docker = await import("./docker.js");
 
     loadCommand = `docker load --input ${docker.DOCKER_IMAGES_PATH}`;
 


### PR DESCRIPTION
The integration test doesn't mock any of our own production code since that is what it is testing. This error was asymptomatic since we didn't actually mock any of our production code, but now we stop giving the misleading impression that we might.