### PR TITLE
test(action): Move `async` imports to top level

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -12,6 +12,11 @@ jest.unstable_mockModule("./util.js", (): typeof import("./util.js") => ({
   execBashCommand: jest.fn<typeof import("./util.js").execBashCommand>(),
 }));
 
+const cache = jest.mocked(await import("@actions/cache"));
+const core = jest.mocked(await import("@actions/core"));
+const util = jest.mocked(await import("./util.js"));
+const docker = await import("./docker.js");
+
 // Expect the given mocks were called in the given order.
 const assertCalledInOrder = <T extends FunctionLike>(
   ...mocks: jest.MockedFunction<T>[]
@@ -33,18 +38,6 @@ const assertCalledInOrder = <T extends FunctionLike>(
 };
 
 describe("Docker images", (): void => {
-  let cache: jest.MockedObject<typeof import("@actions/cache")>;
-  let core: jest.MockedObject<typeof import("@actions/core")>;
-  let util: jest.MockedObject<typeof import("./util.js")>;
-  let docker: typeof import("./docker.js");
-
-  beforeAll(async (): Promise<void> => {
-    cache = jest.mocked(await import("@actions/cache"));
-    core = jest.mocked(await import("@actions/core"));
-    util = jest.mocked(await import("./util.js"));
-    docker = await import("./docker.js");
-  });
-
   const joinAndSplit = (list: string[]): string[] => {
     const joined = list.join("\n");
     return joined.split("\n");

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -15,6 +15,11 @@ jest.unstable_mockModule("node:child_process", () => ({
 jest.mock("@actions/cache");
 jest.mock("@actions/core");
 
+const child_process = jest.mocked(await import("node:child_process"));
+const cache = jest.mocked(await import("@actions/cache"));
+const core = jest.mocked(await import("@actions/core"));
+const docker = await import("./docker.js");
+
 const getKey = (paths: string[], key: string): string =>
   [...paths, key].join(", ");
 
@@ -23,11 +28,6 @@ describe("Integration Test", (): void => {
   const LIST_COMMAND =
     'docker image list --format "{{ .Repository }}:{{ .Tag }}"';
 
-  let child_process: jest.MockedObject<typeof import("node:child_process")>;
-  let cache: jest.MockedObject<typeof import("@actions/cache")>;
-  let core: jest.MockedObject<typeof import("@actions/core")>;
-  let docker: typeof import("./docker.js");
-
   let loadCommand: string;
   let inMemoryCache: Record<string, string>;
   let state: Record<string, string>;
@@ -35,11 +35,6 @@ describe("Integration Test", (): void => {
   let callCount: number;
 
   beforeEach(async (): Promise<void> => {
-    child_process = jest.mocked(await import("node:child_process"));
-    cache = jest.mocked(await import("@actions/cache"));
-    core = jest.mocked(await import("@actions/core"));
-    docker = await import("./docker.js");
-
     loadCommand = `docker load --input ${docker.DOCKER_IMAGES_PATH}`;
 
     cache.saveCache.mockImplementation(

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -7,9 +7,10 @@ jest.unstable_mockModule(
   })
 );
 
+const docker = jest.mocked(await import("./docker.js"));
+
 describe("Main", (): void => {
   test("loads Docker images on module load", async (): Promise<void> => {
-    const docker = jest.mocked(await import("./docker.js"));
     await import("./main.js");
 
     expect(docker.loadDockerImages).lastCalledWith();

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -7,9 +7,10 @@ jest.unstable_mockModule(
   })
 );
 
+const docker = jest.mocked(await import("./docker.js"));
+
 describe("Post", (): void => {
   test("saves Docker images on module load", async (): Promise<void> => {
-    const docker = jest.mocked(await import("./docker.js"));
     await import("./post.js");
 
     expect(docker.saveDockerImages).lastCalledWith();

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -12,17 +12,11 @@ jest.unstable_mockModule("node:child_process", () => ({
 
 jest.mock("@actions/core");
 
+const child_process = jest.mocked(await import("node:child_process"));
+const core = jest.mocked(await import("@actions/core"));
+const util = await import("./util.js");
+
 describe("Util", (): void => {
-  let child_process: jest.MockedObject<typeof import("node:child_process")>;
-  let core: jest.MockedObject<typeof import("@actions/core")>;
-  let util: typeof import("./util.js");
-
-  beforeAll(async (): Promise<void> => {
-    child_process = jest.mocked(await import("node:child_process"));
-    core = jest.mocked(await import("@actions/core"));
-    util = await import("./util.js");
-  });
-
   describe("execBashCommand", (): void => {
     const mockedExec = async (
       command: string,


### PR DESCRIPTION
Top-level `await` allows us to declare and initialize dynamic asynchronous imports at once using `const`. This empowers TypeScript to infer the appropriate types, eliminating the need to specify them explicitly.