### PR TITLE
test(action): Import types statically

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -5,12 +5,16 @@ import { boolean, string, uniqueArray } from "fast-check";
 import type { InputOptions } from "@actions/core";
 import type { FunctionLike } from "jest-mock";
 
+import type { Util } from "../types/aliases.js";
+import type { execBashCommand } from "./util.js";
+
 jest.mock("@actions/cache");
 jest.mock("@actions/core");
 
-jest.unstable_mockModule("./util.js", (): typeof import("./util.js") => ({
-  execBashCommand: jest.fn<typeof import("./util.js").execBashCommand>(),
-}));
+jest.unstable_mockModule(
+  "./util.js",
+  (): Util => ({ execBashCommand: jest.fn<typeof execBashCommand>() })
+);
 
 const cache = jest.mocked(await import("@actions/cache"));
 const core = jest.mocked(await import("@actions/core"));

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -4,13 +4,13 @@ import { string } from "fast-check";
 
 import { consoleOutput } from "./arbitraries/util.js";
 
-import type { ExecOptions } from "node:child_process";
+import type { exec, ExecOptions } from "node:child_process";
 import type { InputOptions } from "@actions/core";
 
 import type { ConsoleOutput } from "./util.js";
 
 jest.unstable_mockModule("node:child_process", () => ({
-  exec: jest.fn<typeof import("node:child_process").exec>(),
+  exec: jest.fn<typeof exec>(),
 }));
 jest.mock("@actions/cache");
 jest.mock("@actions/core");
@@ -64,7 +64,7 @@ describe("Integration Test", (): void => {
   });
 
   const mockExec = (listStderr: string, otherOutput: ConsoleOutput): void => {
-    child_process.exec.mockImplementation(<typeof child_process.exec>((
+    child_process.exec.mockImplementation(<typeof exec>((
       command: string,
       _options: any,
       callback: any

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,9 +1,12 @@
 import { jest } from "@jest/globals";
 
+import type { loadDockerImages } from "./docker.js";
+import type { Docker } from "../types/aliases.js";
+
 jest.unstable_mockModule(
   "./docker.js",
-  (): Partial<typeof import("./docker.js")> => ({
-    loadDockerImages: jest.fn<typeof import("./docker.js").loadDockerImages>(),
+  (): Partial<Docker> => ({
+    loadDockerImages: jest.fn<typeof loadDockerImages>(),
   })
 );
 

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -1,9 +1,12 @@
 import { jest } from "@jest/globals";
 
+import type { saveDockerImages } from "./docker.js";
+import type { Docker } from "../types/aliases.js";
+
 jest.unstable_mockModule(
   "./docker.js",
-  (): Partial<typeof import("./docker.js")> => ({
-    saveDockerImages: jest.fn<typeof import("./docker.js").saveDockerImages>(),
+  (): Partial<Docker> => ({
+    saveDockerImages: jest.fn<typeof saveDockerImages>(),
   })
 );
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -4,10 +4,12 @@ import { string } from "fast-check";
 
 import { consoleOutput, platform } from "./arbitraries/util.js";
 
+import type { exec } from "node:child_process";
+
 import type { ConsoleOutput } from "./util.js";
 
 jest.unstable_mockModule("node:child_process", () => ({
-  exec: jest.fn<typeof import("node:child_process").exec>(),
+  exec: jest.fn<typeof exec>(),
 }));
 
 jest.mock("@actions/core");
@@ -24,7 +26,7 @@ describe("Util", (): void => {
       platform: NodeJS.Platform,
       output: ConsoleOutput
     ): Promise<string> => {
-      child_process.exec.mockImplementationOnce(<typeof child_process.exec>((
+      child_process.exec.mockImplementationOnce(<typeof exec>((
         _command: any,
         _options: any,
         callback: any

--- a/types/aliases.ts
+++ b/types/aliases.ts
@@ -1,0 +1,5 @@
+import type * as docker from "../src/docker.js";
+import type * as util from "../src/util.js";
+
+export type Docker = typeof docker;
+export type Util = typeof util;


### PR DESCRIPTION
Prefer static type imports (using the `import` keyword) to dynamic type imports (using the `import()` function). Unlike regular static imports, static type imports do not interfere with mocking as they compile out, so there is no need to delay them until after our mocks are set up. Introduce `types/aliases.ts` to export convenient names for the shapes of our production modules that we import in our tests. We use these types to ensure that our mocks accurately reflect the shapes of their production counterparts.