### PR TITLE
ci(dictionary): Remove "arbitraries" from custom dictionary

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,3 @@
-arbitraries
 Laven
 ltsc
 nanoserver


### PR DESCRIPTION
It was added to the software-terms dictionary upstream.