### PR TITLE
style(util): Prefer `unknown` to `any` in catch

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -24,8 +24,8 @@ const execBashCommand = async (
     stdout = output.stdout;
     info(stdout);
     error(output.stderr);
-  } catch (error: any) {
-    setFailed(error);
+  } catch (error: unknown) {
+    setFailed(<Error>error);
   }
   return stdout;
 };


### PR DESCRIPTION
Using the `any` type disables the type system, which typescript-eslint objects to, so switch to `unknown`, the only other option permitted by TypeScript.