### PR TITLE
style(util): Prefer `export type` to `export`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -30,4 +30,4 @@ const execBashCommand = async (
   return stdout;
 };
 
-export { ConsoleOutput, execBashCommand };
+export { type ConsoleOutput, execBashCommand };


### PR DESCRIPTION
Clarify and enforce that `ConsoleOutput` is a type rather than a value.