### PR TITLE
chore(Commitizen): Use Poetry version provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,9 @@ build-backend = "poetry.core.masonry.api"
 
 [tool]
   [tool.commitizen]
-  version = "0.3.3"
+  version_provider = "poetry"
   version_files = [
     "package.json:version",
-    "pyproject.toml:version",
     "README.md:docker-cache@"
   ]
   major_version_zero = true


### PR DESCRIPTION
Commitizen recently introduced version providers in v3.0.0 so that the project version number no longer needs to be duplicated between the Commitizen and Poetry configs.