### PR TITLE
ci(tsconfig): Include `types` directory and Jest config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/node18-strictest-esm/tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "include": ["jest.config.ts", "src/**/*.ts", "types/**/*.ts"],
   "exclude": ["**/reports"],
   "compilerOptions": {
     "newLine": "lf",


### PR DESCRIPTION
Include the `types` directory and Jest config in the TypeScript build to ensure that they compile.