### PR TITLE
style(util): Prefer `interface` to `type`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -3,10 +3,10 @@ import { promisify } from "node:util";
 
 import { error, info, setFailed } from "@actions/core";
 
-type ConsoleOutput = {
+interface ConsoleOutput {
   stdout: string;
   stderr: string;
-};
+}
 
 const execBashCommand = async (
   command: string,


### PR DESCRIPTION
The two are often interchangeable, but prefer interfaces when either will do since they are defined statically rather than imperatively, making them slightly simpler.