### PR TITLE
test(docker): Key mocks by reference, not name

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -25,12 +25,11 @@ const docker = await import("./docker.js");
 const assertCalledInOrder = <T extends FunctionLike>(
   ...mocks: jest.MockedFunction<T>[]
 ): void => {
-  const mockCallCounts: Record<string, number> = {};
+  const mockCallCounts = new Map<jest.MockedFunction<T>, number>();
   const callOrders = mocks.map(
     (currentMock: jest.MockedFunction<T>): number => {
-      const mockName = currentMock.getMockName();
-      const callCount = mockCallCounts[mockName] ?? 0;
-      mockCallCounts[mockName] = callCount + 1;
+      const callCount = mockCallCounts.get(currentMock) ?? 0;
+      mockCallCounts.set(currentMock, callCount + 1);
       return <number>currentMock.mock.invocationCallOrder[callCount];
     }
   );


### PR DESCRIPTION
In Jest, mock names make poor keys for identifying mock instances since they are not guaranteed to be unique and default to `"jest.fn()"` unless explicitly specified. All of our mocks are hence currently named `"jest.fn()"`. The key collisions resulted in all call orders after the first being `undefined`, causing `assertCalledInOrder` to always succeed vacuously. Key mocks by reference instead so `assertCalledInOrder` asserts that mocks are called in the specified order as intended.