### PR TITLE
style(util): Prefer `as` to angle brackets

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,7 @@ const execBashCommand = async (
     info(stdout);
     error(output.stderr);
   } catch (error: unknown) {
-    setFailed(<Error>error);
+    setFailed(error as Error);
   }
   return stdout;
 };


### PR DESCRIPTION
Angle bracket casts can create confusion with generics.