### PR TITLE
test(integration): Prefer `??` to `||`

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -57,7 +57,7 @@ describe("Integration Test", (): void => {
       }
     );
 
-    core.getState.mockImplementation((key: string): string => state[key] || "");
+    core.getState.mockImplementation((key: string): string => state[key] ?? "");
 
     core.saveState.mockImplementation((key: string, value: ToString): void => {
       state[key] = value.toString();


### PR DESCRIPTION
Prefer the nullish coalescing operator, `??`, to the logical OR operator, `||`, because the former only coalesces on `null | undefined` rather than on any falsy value.