### PR TITLE
test(integration): Rename `key` to `primaryKey`

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -44,8 +44,8 @@ describe("Integration Test", (): void => {
     loadCommand = `docker load --input ${docker.DOCKER_IMAGES_PATH}`;
 
     cache.saveCache.mockImplementation(
-      (paths: string[], key: string): Promise<number> => {
-        inMemoryCache[getKey(paths, key)] = key;
+      (paths: string[], primaryKey: string): Promise<number> => {
+        inMemoryCache[getKey(paths, primaryKey)] = primaryKey;
         return Promise.resolve(0);
       }
     );


### PR DESCRIPTION
For consistency, refer to the key parameter to the `cache.saveCache` mock by the same name used for the corresponding parameter to the `cache.restoreCache` mock.