### PR TITLE
test(integration): Rename `key` to `primaryKey`

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -25,8 +25,8 @@ interface ToString {
   toString(): string;
 }
 
-const getKey = (paths: string[], key: string): string =>
-  [...paths, key].join(", ");
+const getKey = (paths: string[], primaryKey: string): string =>
+  [...paths, primaryKey].join(", ");
 
 describe("Integration Test", (): void => {
   const EXEC_OPTIONS = { shell: "/usr/bin/bash" };


### PR DESCRIPTION
For consistency, refer to the key parameter to the `setKey` helper function by the same name used for the corresponding parameter to the `cache.saveCache` and `cache.restoreCache` mocks.