### PR TITLE
test(docker): Prefer `concat` to `...`

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -121,7 +121,7 @@ describe("Docker images", (): void => {
       core.getInput.mockReturnValueOnce(readOnly.toString());
       if (!readOnly) {
         core.getState.mockReturnValueOnce(preexistingImages.join("\n"));
-        const images = [...new Set([...preexistingImages, ...newImages])];
+        const images = [...new Set(preexistingImages.concat(newImages))];
         util.execBashCommand.mockResolvedValueOnce(images.join("\n"));
       }
     }


### PR DESCRIPTION
The former has better performance than the spread operator for concatenating arrays.