### PR TITLE
test(docker): Eliminate unnecessary deduplication

### DIFF
--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -121,7 +121,7 @@ describe("Docker images", (): void => {
       core.getInput.mockReturnValueOnce(readOnly.toString());
       if (!readOnly) {
         core.getState.mockReturnValueOnce(preexistingImages.join("\n"));
-        const images = [...new Set(preexistingImages.concat(newImages))];
+        const images = preexistingImages.concat(newImages);
         util.execBashCommand.mockResolvedValueOnce(images.join("\n"));
       }
     }


### PR DESCRIPTION
`preexistingImages` and `newImages` are already guaranteed not to contain any duplicates either within or between them.