### PR TITLE
test(action): Prefer `fullUnicodeString` to `string`

### DIFF
--- a/src/arbitraries/util.ts
+++ b/src/arbitraries/util.ts
@@ -1,4 +1,4 @@
-import { constantFrom, record, string } from "fast-check";
+import { constantFrom, fullUnicodeString, record } from "fast-check";
 
 import type { Arbitrary } from "fast-check";
 
@@ -6,8 +6,8 @@ import type { ConsoleOutput } from "../util.js";
 
 export const consoleOutput = (): Arbitrary<ConsoleOutput> =>
   record({
-    stdout: string(),
-    stderr: string(),
+    stdout: fullUnicodeString(),
+    stderr: fullUnicodeString(),
   });
 
 export const platform = (): Arbitrary<NodeJS.Platform> =>

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -1,6 +1,6 @@
 import { testProp } from "@fast-check/jest";
 import { jest } from "@jest/globals";
-import { boolean, string, uniqueArray } from "fast-check";
+import { boolean, fullUnicodeString, uniqueArray } from "fast-check";
 
 import type { InputOptions } from "@actions/core";
 import type { FunctionLike } from "jest-mock";
@@ -195,7 +195,7 @@ describe("Docker images", (): void => {
 
   testProp(
     "are loaded on cache hit",
-    [string()],
+    [fullUnicodeString()],
     async (key: string): Promise<void> => {
       jest.clearAllMocks();
       await mockedLoadDockerImages(key, true);
@@ -217,7 +217,7 @@ describe("Docker images", (): void => {
 
   testProp(
     "that are present during restore step are recorded on cache miss",
-    [string(), string()],
+    [fullUnicodeString(), fullUnicodeString()],
     async (key: string, images: string): Promise<void> => {
       jest.clearAllMocks();
       await mockedLoadDockerImages(key, false, images);
@@ -233,11 +233,11 @@ describe("Docker images", (): void => {
   testProp(
     "are saved unless cache hit, in read-only mode, or new Docker image list is empty",
     [
-      string(),
+      fullUnicodeString(),
       boolean(),
       boolean(),
-      uniqueArray(string()),
-      uniqueArray(string()),
+      uniqueArray(fullUnicodeString()),
+      uniqueArray(fullUnicodeString()),
     ],
     async (
       key: string,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,7 +1,7 @@
 import { exec } from "node:child_process";
 import { testProp } from "@fast-check/jest";
 import { jest } from "@jest/globals";
-import { string } from "fast-check";
+import { fullUnicodeString } from "fast-check";
 
 import { consoleOutput } from "./arbitraries/util.js";
 import { utilFactory } from "./mocks/util.js";
@@ -180,7 +180,7 @@ describe("Integration Test", (): void => {
 
   testProp(
     "cache misses, then hits",
-    [string(), string(), consoleOutput()],
+    [fullUnicodeString(), fullUnicodeString(), consoleOutput()],
     async (
       key: string,
       listStderr: string,

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,7 +1,7 @@
 import { exec } from "node:child_process";
 import { testProp } from "@fast-check/jest";
 import { jest } from "@jest/globals";
-import { string } from "fast-check";
+import { fullUnicodeString } from "fast-check";
 
 import { consoleOutput, platform } from "./arbitraries/util.js";
 import { utilFactory } from "./mocks/util.js";
@@ -44,7 +44,7 @@ describe("Util", (): void => {
 
     testProp(
       "ferries command output to GitHub Actions on success",
-      [string(), platform(), consoleOutput()],
+      [fullUnicodeString(), platform(), consoleOutput()],
       async (
         command: string,
         platform: NodeJS.Platform,
@@ -67,7 +67,7 @@ describe("Util", (): void => {
 
     testProp(
       "ferries failure to GitHub Actions",
-      [string(), string(), platform(), consoleOutput()],
+      [fullUnicodeString(), fullUnicodeString(), platform(), consoleOutput()],
       async (
         command: string,
         errorMessage: string,


### PR DESCRIPTION
The `string` fast-check arbitrary only samples printable ASCII characters. Thus, it may overlook bugs that are only exposed by Unicode characters.