### PR TITLE
test(docker): Refine Docker images arbitraries

### DIFF
--- a/src/arbitraries/util.ts
+++ b/src/arbitraries/util.ts
@@ -1,4 +1,12 @@
-import { constantFrom, fullUnicodeString, record } from "fast-check";
+import {
+  constantFrom,
+  fullUnicode,
+  fullUnicodeString,
+  record,
+  stringOf,
+  tuple,
+  uniqueArray,
+} from "fast-check";
 
 import type { Arbitrary } from "fast-check";
 
@@ -10,5 +18,29 @@ export const consoleOutput = (): Arbitrary<ConsoleOutput> =>
     stderr: fullUnicodeString(),
   });
 
+export const dockerImages = (): Arbitrary<string[]> =>
+  uniqueArray(
+    stringOf(
+      fullUnicode().filter((char: string): boolean => char !== "\n"),
+      { minLength: 1 }
+    )
+  );
+
 export const platform = (): Arbitrary<NodeJS.Platform> =>
   constantFrom("linux", "win32");
+
+/**
+ * @template T
+ * @param arrArbA an arbitrary that generates an array of T
+ * @param arrArbB an arbitrary that generates an array of T
+ * @returns an arbitrary that generates a 2-tuple of arrays of T with no overlap
+ */
+export const uniquePair = <T>(
+  arrArbA: Arbitrary<T[]>,
+  arrArbB: Arbitrary<T[]>
+): Arbitrary<[T[], T[]]> =>
+  tuple(arrArbA, arrArbB).map(([arrayA, arrayB]: [T[], T[]]): [T[], T[]] => {
+    const setA = new Set(arrayA);
+    arrayB = arrayB.filter((elem: T): boolean => !setA.has(elem));
+    return [arrayA, arrayB];
+  });


### PR DESCRIPTION
Introduce `uniquePair` arbitrary in `src/arbitraries/util.ts` that generates a 2-tuple of arrays with no overlap. Docker images can either be preexisting, that is present during the main step, or new, that is only present during the post step. Hence, restrict fast-check to cases without duplicates between preexisting and new Docker images. Previously, these duplicates were filtered out after the fact. Move this filtering into the arbitrary to produce more intuitive counterexamples. Modify the example that tested handling of duplicates accordingly.

Introduce `dockerImages` arbitrary in `src/arbitraries/util.ts` that forbids the empty string and newlines. Docker image names can neither be empty nor contain newlines, so there's no value in testing these cases that complicate test logic. Remove the no-longer-needed helper function `joinAndSplit`, which previously accounted for these edge cases.