### PR TITLE
chore(@types/prettier): Remove no longer needed dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/eslint": "8.44.1",
     "@types/jest": "29.5.3",
     "@types/node": "18.17.2",
-    "@types/prettier": "2.7.2",
     "@typescript-eslint/eslint-plugin": "6.2.1",
     "@typescript-eslint/parser": "6.2.1",
     "@vercel/ncc": "0.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,13 +1362,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:2.7.2":
-  version: 2.7.2
-  resolution: "@types/prettier@npm:2.7.2"
-  checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
-  languageName: node
-  linkType: hard
-
 "@types/responselike@npm:^1.0.0":
   version: 1.0.0
   resolution: "@types/responselike@npm:1.0.0"
@@ -2496,7 +2489,6 @@ __metadata:
     "@types/eslint": 8.44.1
     "@types/jest": 29.5.3
     "@types/node": 18.17.2
-    "@types/prettier": 2.7.2
     "@typescript-eslint/eslint-plugin": 6.2.1
     "@typescript-eslint/parser": 6.2.1
     "@vercel/ncc": 0.36.1


### PR DESCRIPTION
Prettier 3+ includes its own type definitions, so `@types/prettier` is no longer needed.