### PR TITLE
docs(Yarn): Document need for `darwin` architecture

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,9 +9,11 @@ plugins:
     spec: "https://raw.githubusercontent.com/mhassan1/yarn-plugin-licenses/v0.12.0/bundles/@yarnpkg/plugin-licenses.js"
 
 supportedArchitectures:
+  # The Yarn licenses plugin needs all dependencies installed in order to list
+  # their licenses without crashing.
   os:
     - current
-    - darwin
+    - darwin # for fsevents, a MacOS-only transitive dependency of Jest
 
 # Keep in sync with package.json.
 yarnPath: .yarn/releases/yarn-3.6.3.cjs


### PR DESCRIPTION
The Yarn licenses plugin requires that all dependencies are installed.