### PR TITLE
chore(VSCode): Remove `eslint.packageManager`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
   "editor.tabSize": 2,
   "editorconfig.generateAuto": false,
   "eslint.nodePath": ".yarn/sdks",
-  "eslint.packageManager": "yarn",
   "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
This setting is deprecated since the ESLint VSCode extension now detects the package manager automatically.