### PR TITLE
test(jest.config): Treat `*.ts` files as ESM

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,7 @@ const config: JestConfigWithTsJest = {
       statements: 100,
     },
   },
+  extensionsToTreatAsEsm: [".ts"],
   moduleFileExtensions: ["ts", "js"],
   resetMocks: true,
   rootDir: "src",


### PR DESCRIPTION
Jest began recommending use of this setting in TypeScript ESM projects when it was introduced in v27.