### PR TITLE
ci(python-safety-dependencies-check): Remove hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,12 +85,6 @@ repos:
     hooks:
       - id: license-finder
 
-  ## Python
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.2
-    hooks:
-      - id: python-safety-dependencies-check
-
   ## Natural language
   - repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.4


### PR DESCRIPTION
Trivy and Grype were added to MegaLinter in v6.0.0 and v7.2.0, respectively. Both scan for security vulnerabilities in Poetry dependencies. Hence, we no longer require a dedicated pre-commit hook for this purpose.