### PR TITLE
ci(pre-commit): Add and run new `yarn-sdks` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: yarn-install
       - id: yarn-dedupe
       - id: yarn-audit
+      - id: yarn-sdks
       - id: yarn-build
       - id: yarn-test
       - id: megalinter-incremental

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
   "python.terminal.activateEnvInCurrentTerminal": true,
   "search.exclude": {
     "/dist": true,
+    "**/.pnp.*": true,
     "**/.yarn": true
   },
   "typescript.enablePromptUseWorkspaceTsdk": true,


### PR DESCRIPTION
The `yarn-sdks` hook was recently added to our pre-commit-hooks repository. Use it to ensure that our Yarn SDKs remain up-to-date.