### PR TITLE
ci(markdownlint): Replace deprecated rule alias

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,3 @@
 # Commitizen produces duplicate headings in CHANGELOG.md.
-no-duplicate-header:
+no-duplicate-heading:
   siblings_only: true


### PR DESCRIPTION
The `-header` aliases were deprecated in markdownlint v0.9.0; `-heading` is recommended instead.