### PR TITLE
fix(Node.js): Upgrade from node16 to node20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ outputs:
       The ferried output of the official GitHub cache action. True on cache hit
       (even if the subsequent docker load failed) and false on cache miss.
 runs:
-  using: node16
+  using: node20
   main: dist/main/index.js
   post-if: success()
   post: dist/post/index.js


### PR DESCRIPTION
Closes #613.

We are already using Node.js 20.10.0 via asdf, so use the same major version of Node.js in the action.