### PR TITLE
ci(Trivy): Port `.trivyignore` to `.trivyignore.yaml`

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,7 @@
+Dockerfiles
+ignorefile
 Laven
 npmcli
 npmpackagejsonlintignore
+trivy
 trivyignore

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -1,6 +1,7 @@
 EXTENDS: https://raw.githubusercontent.com/ScribeMD/.github/0.14.15/.github/base.mega-linter.yaml
 JAVASCRIPT_ES_CLI_EXECUTABLE: [node, .yarn/releases/yarn-4.0.2.cjs, run, eslint]
 # Work around https://github.com/oxsecurity/megalinter/issues/2500.
+REPOSITORY_TRIVY_ARGUMENTS: --ignorefile .trivyignore.yaml
 SPELL_CSPELL_PRE_COMMANDS:
   - command: npm install @cspell/dict-win32@2.0.2
     continue_if_failed: false

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,0 @@
-AVD-DS-0002 # Dockerfile only used for testing, so it's okay that user is root.
-AVD-DS-0026 # Dockerfile only used for testing, so health check isn't needed.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,11 @@
+misconfigurations:
+  - id: AVD-DS-0002
+    paths:
+      - Dockerfile
+      - Dockerfile.windows
+    statement: Dockerfiles only used for testing, so it's okay that user is root.
+  - id: AVD-DS-0026
+    paths:
+      - Dockerfile
+      - Dockerfile.windows
+    statement: Dockerfiles only used for testing, so health check isn't needed.


### PR DESCRIPTION
Use the more expressive YAML config format recently introduced in v0.45.0.