### PR TITLE
fix: filter out anonymous images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ Cache Docker Images Whether Built or Pulled
   - [Usage](#usage)
   - [Inputs](#inputs)
     - [Required](#required)
+      - [`key`](#key)
     - [Optional](#optional)
+      - [`read-only`](#read-only)
   - [Outputs](#outputs)
     - [`cache-hit`](#cache-hit)
+  - [Anonymous image names](#anonymous-image-names)
   - [Supported Runners](#supported-runners)
   - [Permissions](#permissions)
   - [Changelog](#changelog)
@@ -93,6 +96,30 @@ True on cache hit (even if the subsequent
 [`docker load`](https://docs.docker.com/engine/reference/commandline/load/)
 failed) and false on cache miss. See also
 [skipping steps based on cache-hit](https://github.com/marketplace/actions/cache#Skipping-steps-based-on-cache-hit).
+
+## Anonymous image names
+
+Anonymous images (eg. `<none>:<none>`) will be skipped during caching
+via `docker save`, as we use the `{{ .Repository }}:{{ .Tag }}` format
+to reference which images to save.
+
+`docker save {{ .ID }}` would allow us to cache/load such anonymous images.
+However, the docker client loses reference to the original
+`{{ .Repository }}:{{ .Tag }}` value upon `docker load` for previously
+named images, resulting in:
+
+```sh
+my-image:tag
+```
+
+to become
+
+```sh
+<none>:<none>
+```
+
+Be sure to name + tag those images you wish to be handled by the caching
+and loading operations in this action.
 
 ## Supported Runners
 

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -256,7 +256,10 @@ describe("Docker images", (): void => {
         assertSaveCacheHit(key);
       } else if (readOnly) {
         assertSaveReadOnly(key);
-      } else if (newImages.length === 0 || newImages.every((img) => img == "<none>:<none>")) {
+      } else if (
+        newImages.length === 0 ||
+        newImages.every((img) => img == "<none>:<none>")
+      ) {
         assertNoNewImagesToSave();
       } else {
         assertSaveCacheMiss(key, newImages);

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -256,7 +256,7 @@ describe("Docker images", (): void => {
         assertSaveCacheHit(key);
       } else if (readOnly) {
         assertSaveReadOnly(key);
-      } else if (newImages.length === 0) {
+      } else if (newImages.length === 0 || newImages.every((img) => img == "<none>:<none>")) {
         assertNoNewImagesToSave();
       } else {
         assertSaveCacheMiss(key, newImages);
@@ -268,6 +268,7 @@ describe("Docker images", (): void => {
         ["my-key", false, false, [["preexisting-image"], []]],
         ["my-key", false, true, [["preexisting-image"], ["new-image"]]],
         ["my-key", true, false, [["preexisting-image"], ["new-image"]]],
+        ["my-key", false, false, [["preexisting-image"], ["<none>:<none>"]]],
       ],
     },
   );

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -42,7 +42,8 @@ const saveDockerImages = async (): Promise<void> => {
     const images = await execBashCommand(LIST_COMMAND);
     const imagesList = images.split("\n");
     const newImages = imagesList.filter(
-      (image: string): boolean => !preexistingImages.includes(image) && image !== "<none>:<none>",
+      (image: string): boolean =>
+        !preexistingImages.includes(image) && image !== "<none>:<none>",
     );
     if (newImages.length === 0) {
       info("No Docker images to save");

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -42,7 +42,7 @@ const saveDockerImages = async (): Promise<void> => {
     const images = await execBashCommand(LIST_COMMAND);
     const imagesList = images.split("\n");
     const newImages = imagesList.filter(
-      (image: string): boolean => !preexistingImages.includes(image),
+      (image: string): boolean => !preexistingImages.includes(image) && image !== "<none>:<none>",
     );
     if (newImages.length === 0) {
       info("No Docker images to save");


### PR DESCRIPTION
relates to https://github.com/ScribeMD/docker-cache/issues/572

through local testing, i'm finding that using `docker save {{ .ID }}` actually anonymizes named images upon `docker load`

given this docker client behavior, i'm thinking we might just want to filter out the anonymous images (these aren't being cached currently anyway, due to the docker client not accepting `<none>:<none>` as a save-able image input)

I dont see the tests running in CI/CD, so here's an output of `npm run test`

```
npm run test

> docker-cache@0.3.7 test
> yarn run tsc && yarn run jest:esm

(node:92973) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/main.test.ts
(node:92972) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/post.test.ts
(node:92971) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/util.test.ts
(node:92969) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/docker.test.ts
(node:92970) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/integration.test.ts
-----------------|---------|----------|---------|---------|-------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------|---------|----------|---------|---------|-------------------
All files        |     100 |      100 |     100 |     100 |
 src             |     100 |      100 |     100 |     100 |
  docker.ts      |     100 |      100 |     100 |     100 |
  main.ts        |     100 |      100 |     100 |     100 |
  post.ts        |     100 |      100 |     100 |     100 |
  util.ts        |     100 |      100 |     100 |     100 |
 src/arbitraries |     100 |      100 |     100 |     100 |
  util.ts        |     100 |      100 |     100 |     100 |
 src/mocks       |     100 |      100 |     100 |     100 |
  util.ts        |     100 |      100 |     100 |     100 |
-----------------|---------|----------|---------|---------|-------------------

Test Suites: 5 passed, 5 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        2.921 s, estimated 5 s
Ran all test suites.
```