### PR TITLE
chore(Poetry): Disable package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ build-backend = "poetry.core.masonry.api"
   major_version_zero = true
 
   [tool.poetry]
+  package-mode = false
   name = "docker-cache"
   version = "0.4.0"
   description = "Cache Docker Images Whether Built or Pulled"


### PR DESCRIPTION
We only use Poetry for dependency management, not packaging.